### PR TITLE
Fix wasm build script configuration for OpenSSL

### DIFF
--- a/scripts/build-wasm.js
+++ b/scripts/build-wasm.js
@@ -82,12 +82,11 @@ const configureArgs = [
   'no-shared',
   'no-sock',
   'no-stdio',
-  'no-thread-pool',
   'no-threads',
   'no-ui-console',
   '--prefix=/usr',
   '--openssldir=/etc/ssl',
-  'linux-generic32'
+  'wasm32-wasi'
 ].join(' ');
 
 // Determine number of CPU cores for parallel build


### PR DESCRIPTION
This PR updates the OpenSSL build configuration in the `scripts/build-wasm.js` file. The `no-thread-pool` option has been removed, as it caused an unsupported options error during the build process. Additionally, the target architecture has been changed from `linux-generic32` to `wasm32-wasi`, which is more appropriate for WebAssembly builds. This change should resolve the build issues and allow for successful execution of the `npm run build:wasm` command.