### PR TITLE
Fix WASM Build Script Target for Emscripten

### DIFF
--- a/scripts/build-wasm.js
+++ b/scripts/build-wasm.js
@@ -86,7 +86,8 @@ const configureArgs = [
   'no-ui-console',
   '--prefix=/usr',
   '--openssldir=/etc/ssl',
-  'wasm32-wasi'
+  // Use a generic 32-bit target for Emscripten. emcc does not support the wasm32-wasi target.
+  'linux-generic32'
 ].join(' ');
 
 // Determine number of CPU cores for parallel build


### PR DESCRIPTION
This pull request resolves an error encountered when building OpenSSL for WebAssembly using Emscripten. The original script attempted to use the unsupported target 'wasm32-wasi'. Instead, it has been updated to use the 'linux-generic32' target, which is compatible with Emscripten. This change allows the build script to execute successfully, facilitating the compilation process for OpenSSL in the web environment.